### PR TITLE
Add updateItem hook

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -148,7 +148,6 @@ Hooks.on('updateItem', async (weapon, update, options, userID) => {
 
     // delete the old entry to avoid duplicate spellcasting entries
     const { actor } = weapon;
-    console.log("update - actor: " + actor);
     const spellcastingEntries = actor.items.filter(i => i.type === 'spellcastingEntry');
     const oldspellcastingEntry = spellcastingEntries.find(i => i.getFlag(moduleID, 'staveID') === weapon.id);
     if (oldspellcastingEntry) oldspellcastingEntry.delete();


### PR DESCRIPTION
This uses the update item hook to delete and recreate the spellcasting entry on the character sheet. I'm sure there's a more graceful way to do this (like reading and updating the spellcasting entry), but this should work.

This solves Issue #9 