### PR TITLE
Fix regex to account for if there is no {} present in compendium match

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -213,7 +213,7 @@ async function createStaveSpellcastingEntry(stave, actor, existingEntry = null) 
         const match = description.match(regex);
         if (!match) continue;
 
-        const strs = match[0].match(/(@UUID\[Compendium\.|@Compendium\[)(.*?)].*?}/g);
+        const strs = match[0].match(/(@UUID\[Compendium\.|@Compendium\[)(.*?)]({.*?})?/g);
         for (const str of strs) {
             const UUID = str.split('[')[1].split(']')[0].replace('Compendium.', '');
             const spell = await fromUuid("Compendium." + UUID);


### PR DESCRIPTION
Dragging Staff of Fire into actor sheet no longer fails.

![image](https://github.com/jessev14/pf2e-staves/assets/7503160/58337c83-2c1b-45d8-ab06-c286017975fc)

Fix #30 