### PR TITLE
Attempted fix for constant database operations

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -208,6 +208,11 @@ async function createStaveSpellcastingEntry(stave, actor, existingEntry = null) 
     const spells = [];
     const description = stave.system.description.value;
     const slotLevels = ['Cantrips?', '1st', '2nd', '3rd', '4th', '5th', '6th', '7th', '8th', '9th', '10th', '11th'];
+
+    // If the previous and current descriptions match, assume no changes are needed and skip this
+    const prevDesc = existingEntry?.getFlag(moduleID, "prevDescription");
+    if (prevDesc === description) return;
+
     for (let i = 0; i < slotLevels.length; i++) {
         const regex = new RegExp(`${slotLevels[i]}.*@(UUID|Compendium).*\n`);
         const match = description.match(regex);
@@ -277,7 +282,8 @@ async function createStaveSpellcastingEntry(stave, actor, existingEntry = null) 
             flags: {
                 [moduleID]: {
                     staveID: stave.id,
-                    charges: getHighestSpellslot(actor)
+                    charges: getHighestSpellslot(actor),
+                    prevDescription: description
                 }
             }
         }
@@ -286,6 +292,7 @@ async function createStaveSpellcastingEntry(stave, actor, existingEntry = null) 
     } else {
         for (const spell of existingEntry.spells) await spell.delete();
         for (const spell of spells) await existingEntry.addSpell(spell);
+        await existingEntry.setFlag(moduleID, "prevDescription", description);
     }
 }
 


### PR DESCRIPTION
Attempted fix to remove the constant database operations triggered whenever the staff is updated. The way it works is that it caches the staff description into the spellcasting entry flags, then whenever the staff is updated, it compares the cached and current descriptions. If they match, nothing the module cares about should have changed, and so there's no need to update the spellcasting entry. This should prevent the constant database operations whenever the staff is otherwise changed, eg. the staff changes grip.