### PR TITLE
Add deprecation and alternative to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This module is deprecated; for a V12+ replacement, try using [PF2e Dailies](https://github.com/reonZ/pf2e-dailies) instead.
+
+-----
+
 ![All Downloads](https://img.shields.io/github/downloads/jessev14/pf2e-staves/total?style=for-the-badge)
 
 ![Latest Release Download Count](https://img.shields.io/github/downloads/jessev14/pf2e-staves/latest/module.zip)


### PR DESCRIPTION
Please either add such a deprecation notice with a link to the alternative module, or update this module (I assume you don't want to maintain this module anymore, because the latest update was 7 months ago)